### PR TITLE
Adds support for tuples and removes limitation on maps

### DIFF
--- a/jem.js
+++ b/jem.js
@@ -123,7 +123,7 @@ if (typeof Inaka.Jem == 'undefined') Inaka.Jem = {};
      var obj = {};
      for(var k = 0; k < l; k++)
      {
-       var [key, i] = _decodeString(dv, i + 1);
+       var [key, i] = _decodeValue(dv, i);
        var [value, i] = _decodeValue(dv, i);
        obj[key] = value;
      }

--- a/jem.js
+++ b/jem.js
@@ -54,6 +54,10 @@ if (typeof Inaka.Jem == 'undefined') Inaka.Jem = {};
          return [dv.getInt32(i + 1), i + 5];
        case 100:
          return _decodeAtom(dv, i + 1);
+       case 104:
+         return _decodeTuple(dv, i + 1, 1);
+       case 105:
+         return _decodeTuple(dv, i + 1, 4);
        case 106:
          return [[], i + 2];
        case 107:
@@ -76,6 +80,29 @@ if (typeof Inaka.Jem == 'undefined') Inaka.Jem = {};
      dv.setUint16(i + 1, 4);
      dv.setUint32(i + 3, 1853189228);
      return [dv, i + 7];
+   }
+
+   function _decodeTuple(dv, i, lenBytes)
+   {
+     var l;
+     if(lenBytes == 1)
+     {
+       l = dv.getUint8(i);
+       i += 1;
+     }
+     else
+     {
+       l = dv.getUint32(i);
+       i += 4;
+     }
+
+     var tup = [];
+     for(var k = 0; k < l; k++)
+     {
+       var [el, i] = _decodeValue(dv, i);
+       tup[k] = el;
+     }
+     return [tup, i];
    }
 
    function _decodeAtom(dv, i)


### PR DESCRIPTION
Tuples are now parsed as arrays. Using arrays makes some sense because ES6 allows something similar to pattern matching when destructuring them. As you can expect, you can't generate tuples since there's no way to call ``Jem.encode`` with any JS data type that can be unequivocally interpreted by the encoder as a tuple.

Also, Jem can now parse maps where keys are not just binaries or strings. This is useful when handling atoms, but this is not a carte blanche to send any valid erlang maps you have, since not everything can be a dictionary key in JS.